### PR TITLE
Add qcheck to opam test dependencies

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -27,5 +27,6 @@ depends: [
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "ptime"
+  "qcheck" {test}
 ]
 available: [ ocaml-version >= "4.02.3" ]


### PR DESCRIPTION
Forgot that in #3, sorry.
