### PR TITLE
Add Syslog_message.encode_local

### DIFF
--- a/src/syslog_message.ml
+++ b/src/syslog_message.ml
@@ -235,16 +235,26 @@ let to_string msg =
 
 let pp ppf msg = Format.pp_print_string ppf (to_string msg)
 
-let encode ?(len=1024) msg =
+let encode_gen encode ?(len=1024) msg =
   let facse = int_of_facility msg.facility * 8 + int_of_severity msg.severity
   and ts = Rfc3164_Timestamp.encode msg.timestamp
   in
-  let msgstr = Printf.sprintf "<%d>%s %s %s" facse ts msg.hostname msg.message
+  let msgstr = encode facse ts msg.hostname msg.message
   in
   if len > 0 && String.length msgstr > len then
     String.with_range ~first:0 ~len:len msgstr
   else
     msgstr
+
+let encode ?len msg =
+  let encode facse ts hostname msg =
+    Printf.sprintf "<%d>%s %s %s" facse ts hostname msg
+  in
+  encode_gen encode ?len msg
+
+let encode_local ?len msg =
+  let encode facse ts _ msg = Printf.sprintf "<%d>%s %s" facse ts msg in
+  encode_gen encode ?len msg
 
 let parse_priority_value s =
   let l = String.length s in

--- a/src/syslog_message.mli
+++ b/src/syslog_message.mli
@@ -94,6 +94,10 @@ val decode : ctx:ctx -> string -> t option
     truncated. *)
 val encode : ?len:int -> t -> string
 
+(** [encode_local ~len t] behaves as {!encode} except that the message is
+    formatted for sending to the local syslog daemon (e.g. on [/dev/log]). *)
+val encode_local : ?len:int -> t -> string
+
 (** RFC 3164 Timestamps *)
 module Rfc3164_Timestamp : sig
 


### PR DESCRIPTION
When communicating with syslog locally, the syslog message should not include the hostname.

See the [glibc sources](https://sourceware.org/git/?p=glibc.git;a=blob;f=misc/syslog.c;h=644dbe80ec0b90d208515c95a53ba2d1ea86dd74;hb=HEAD#l193) and also rsyslogd [imuxsock docs](https://www.rsyslog.com/doc/v8-stable/configuration/modules/imuxsock.html#syssock-parsehostname)