### PR TITLE
extend type t to contain tag and message (both type string), fixes #18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.02 PACKAGE=syslog-message TESTS=true
   - OCAML_VERSION=4.03 PACKAGE=syslog-message TESTS=true
   - OCAML_VERSION=4.04 PACKAGE=syslog-message TESTS=true
   - OCAML_VERSION=4.05 PACKAGE=syslog-message TESTS=true
   - OCAML_VERSION=4.06 PACKAGE=syslog-message TESTS=true
+  - OCAML_VERSION=4.07 PACKAGE=syslog-message TESTS=true

--- a/src/dune
+++ b/src/dune
@@ -5,4 +5,4 @@
   (name        syslog_message)
   (public_name syslog-message)
   (synopsis    "Syslog Message Parser")
-  (libraries   astring ptime))
+  (libraries   astring ptime rresult))

--- a/src/syslog_message.ml
+++ b/src/syslog_message.ml
@@ -160,7 +160,7 @@ type t = {
   timestamp : Ptime.t;
   hostname  : string;
   tag       : string;
-  message   : string
+  content   : string
 }
 
 module Rfc3164_Timestamp = struct
@@ -228,8 +228,8 @@ let to_string msg =
   and timestamp = Rfc3164_Timestamp.encode msg.timestamp
   in
   Printf.sprintf
-    "Facility: %s Severity: %s Timestamp: %s Hostname: %s Tag: %sMessage: %s\n%!"
-    facility severity timestamp msg.hostname msg.tag msg.message
+    "Facility: %s Severity: %s Timestamp: %s Hostname: %s Tag: %s Content: %s\n%!"
+    facility severity timestamp msg.hostname msg.tag msg.content
 
 let pp ppf msg = Format.pp_print_string ppf (to_string msg)
 
@@ -237,7 +237,7 @@ let encode_gen encode ?(len=1024) msg =
   let facse = int_of_facility msg.facility * 8 + int_of_severity msg.severity
   and ts = Rfc3164_Timestamp.encode msg.timestamp
   in
-  let msgstr = encode facse ts msg.hostname msg.tag msg.message
+  let msgstr = encode facse ts msg.hostname msg.tag msg.content
   in
   if len > 0 && String.length msgstr > len then
     String.with_range ~first:0 ~len:len msgstr
@@ -316,7 +316,7 @@ let decode ~ctx data : (t, [> Rresult.R.msg ]) result =
     parse_priority_value data >>= fun (facility, severity, data) ->
     parse_timestamp data ctx >>= fun (timestamp, data, ctx) ->
     parse_hostname data ctx >>= fun (hostname, data) ->
-    parse_tag data >>= fun (tag, message) ->
-    Ok { facility; severity; timestamp; hostname; tag; message }
+    parse_tag data >>= fun (tag, content) ->
+    Ok { facility; severity; timestamp; hostname; tag; content }
   else
     Error (`Msg "could not decode data")

--- a/src/syslog_message.ml
+++ b/src/syslog_message.ml
@@ -1,5 +1,7 @@
 open Astring
 
+open Rresult.R.Infix
+
 type facility =
   | Kernel_Message
   | User_Level_Messages
@@ -25,7 +27,6 @@ type facility =
   | Local5
   | Local6
   | Local7
-  | Invalid_Facility
 
 let int_of_facility = function
   | Kernel_Message -> 0
@@ -52,34 +53,33 @@ let int_of_facility = function
   | Local5 -> 21
   | Local6 -> 22
   | Local7 -> 23
-  | Invalid_Facility -> failwith "Invalid_Facility"
 
 let facility_of_int = function
-  | 0  -> Kernel_Message
-  | 1  -> User_Level_Messages
-  | 2  -> Mail_System
-  | 3  -> System_Daemons
-  | 4  -> Security_Authorization_Messages
-  | 5  -> Messages_Generated_Internally_By_Syslogd
-  | 6  -> Line_Printer_Subsystem
-  | 7  -> Network_News_Subsystem
-  | 8  -> UUCP_subsystem
-  | 9  -> Clock_Daemon
-  | 10 -> Security_Authorization_Messages_10
-  | 11 -> Ftp_Daemon
-  | 12 -> Ntp_Subsystem
-  | 13 -> Log_Audit
-  | 14 -> Log_Alert
-  | 15 -> Clock_Daemon_15
-  | 16 -> Local0
-  | 17 -> Local1
-  | 18 -> Local2
-  | 19 -> Local3
-  | 20 -> Local4
-  | 21 -> Local5
-  | 22 -> Local6
-  | 23 -> Local7
-  | _  -> Invalid_Facility
+  | 0  -> Some Kernel_Message
+  | 1  -> Some User_Level_Messages
+  | 2  -> Some Mail_System
+  | 3  -> Some System_Daemons
+  | 4  -> Some Security_Authorization_Messages
+  | 5  -> Some Messages_Generated_Internally_By_Syslogd
+  | 6  -> Some Line_Printer_Subsystem
+  | 7  -> Some Network_News_Subsystem
+  | 8  -> Some UUCP_subsystem
+  | 9  -> Some Clock_Daemon
+  | 10 -> Some Security_Authorization_Messages_10
+  | 11 -> Some Ftp_Daemon
+  | 12 -> Some Ntp_Subsystem
+  | 13 -> Some Log_Audit
+  | 14 -> Some Log_Alert
+  | 15 -> Some Clock_Daemon_15
+  | 16 -> Some Local0
+  | 17 -> Some Local1
+  | 18 -> Some Local2
+  | 19 -> Some Local3
+  | 20 -> Some Local4
+  | 21 -> Some Local5
+  | 22 -> Some Local6
+  | 23 -> Some Local7
+  | _  -> None
 
 let string_of_facility = function
   | Kernel_Message -> "kern"
@@ -106,7 +106,6 @@ let string_of_facility = function
   | Local5 -> "local5"
   | Local6 -> "local6"
   | Local7 -> "local7"
-  | Invalid_Facility -> "invalid"
 
 type severity =
   | Emergency
@@ -117,7 +116,6 @@ type severity =
   | Notice
   | Informational
   | Debug
-  | Invalid_Severity
 
 let int_of_severity = function
   | Emergency -> 0
@@ -128,18 +126,17 @@ let int_of_severity = function
   | Notice -> 5
   | Informational -> 6
   | Debug -> 7
-  | Invalid_Severity -> failwith "Invalid_Severity"
 
 let severity_of_int = function
-  | 0 -> Emergency
-  | 1 -> Alert
-  | 2 -> Critical
-  | 3 -> Error
-  | 4 -> Warning
-  | 5 -> Notice
-  | 6 -> Informational
-  | 7 -> Debug
-  | _ -> Invalid_Severity
+  | 0 -> Some Emergency
+  | 1 -> Some Alert
+  | 2 -> Some Critical
+  | 3 -> Some Error
+  | 4 -> Some Warning
+  | 5 -> Some Notice
+  | 6 -> Some Informational
+  | 7 -> Some Debug
+  | _ -> None
 
 let string_of_severity = function
   | Emergency -> "emerg"
@@ -150,7 +147,6 @@ let string_of_severity = function
   | Notice -> "notice"
   | Informational -> "info"
   | Debug -> "debug"
-  | Invalid_Severity -> "invalid"
 
 type ctx = {
   timestamp    : Ptime.t;
@@ -163,6 +159,7 @@ type t = {
   severity  : severity;
   timestamp : Ptime.t;
   hostname  : string;
+  tag       : string;
   message   : string
 }
 
@@ -201,11 +198,12 @@ module Rfc3164_Timestamp = struct
     let ((_, month, day), ((h, m, s), _)) = Ptime.to_date_time ts in
     Printf.sprintf "%s %.2i %.2i:%.2i:%.2i" (month_name_of_int month) day h m s
 
-  let decode s year =
+  let decode s year : (Ptime.t * string, [> Rresult.R.msg ]) result =
     let open String in
     let tslen = 16 in
     match length s with
-    | l when l < tslen -> None
+    | l when l < tslen ->
+      Error (`Msg "timestamp too short, must be at least 16 bytes")
     | l ->
       let month = int_of_month_name @@ with_range ~first:0 ~len:3 s in
       let day = with_range ~first:4 ~len:2 s |> trim |> to_int in
@@ -213,15 +211,15 @@ module Rfc3164_Timestamp = struct
       let minute = with_range ~first:10 ~len:2 s |> to_int in
       let second = with_range ~first:13 ~len:2 s |> to_int in
       match month, day, hour, minute, second with
-      | None, _, _, _, _ -> None
-      | _, None, _, _, _ -> None
-      | _, _, None, _, _ -> None
-      | _, _, _, None, _ -> None
-      | _, _, _, _, None -> None
+      | None, _, _, _, _ -> Error (`Msg "couldn't decode month in timestamp")
+      | _, None, _, _, _ -> Error (`Msg "couldn't decode day in timestamp")
+      | _, _, None, _, _ -> Error (`Msg "couldn't decode hours in timestamp")
+      | _, _, _, None, _ -> Error (`Msg "couldn't decode minutes in timestamp")
+      | _, _, _, _, None -> Error (`Msg "couldn't decode seconds in timestamp")
       | Some month, Some day, Some hour, Some min, Some sec ->
         match Ptime.of_date_time ((year, month, day), ((hour, min, sec), 0)) with
-        | None -> None
-        | Some ts -> Some (ts, with_range ~first:tslen ~len:(l - tslen) s)
+        | None -> Error (`Msg "couldn't transform timestamp to ptime.t")
+        | Some ts -> Ok (ts, with_range ~first:tslen ~len:(l - tslen) s)
 end
 
 let to_string msg =
@@ -230,8 +228,8 @@ let to_string msg =
   and timestamp = Rfc3164_Timestamp.encode msg.timestamp
   in
   Printf.sprintf
-    "Facility: %s Severity: %s Timestamp: %s Hostname: %s Message: %s\n%!"
-    facility severity timestamp msg.hostname msg.message
+    "Facility: %s Severity: %s Timestamp: %s Hostname: %s Tag: %sMessage: %s\n%!"
+    facility severity timestamp msg.hostname msg.tag msg.message
 
 let pp ppf msg = Format.pp_print_string ppf (to_string msg)
 
@@ -239,7 +237,7 @@ let encode_gen encode ?(len=1024) msg =
   let facse = int_of_facility msg.facility * 8 + int_of_severity msg.severity
   and ts = Rfc3164_Timestamp.encode msg.timestamp
   in
-  let msgstr = encode facse ts msg.hostname msg.message
+  let msgstr = encode facse ts msg.hostname msg.tag msg.message
   in
   if len > 0 && String.length msgstr > len then
     String.with_range ~first:0 ~len:len msgstr
@@ -247,81 +245,79 @@ let encode_gen encode ?(len=1024) msg =
     msgstr
 
 let encode ?len msg =
-  let encode facse ts hostname msg =
-    Printf.sprintf "<%d>%s %s %s" facse ts hostname msg
+  let encode facse ts hostname tag msg =
+    Printf.sprintf "<%d>%s %s %s%s" facse ts hostname tag msg
   in
   encode_gen encode ?len msg
 
 let encode_local ?len msg =
-  let encode facse ts _ msg = Printf.sprintf "<%d>%s %s" facse ts msg in
+  let encode facse ts _ tag msg = Printf.sprintf "<%d>%s %s%s" facse ts tag msg in
   encode_gen encode ?len msg
 
-let parse_priority_value s =
+let parse_priority_value s :
+  (facility * severity * string, [> `Msg of string ]) result =
   let l = String.length s in
   if String.get s 0 <> '<' then
-    None
+    Error (`Msg "couldn't parse priority: expected '<'")
   else
-    match String.find (fun x -> x = '>') s with
-    | None -> None
-    | Some pri_end when pri_end > 4 || l <= pri_end + 1 -> None
+    match String.find ((=) '>') s with
+    | None -> Error (`Msg "couldn't parse priority: no '>' found")
+    | Some pri_end when pri_end > 4 || l <= pri_end + 1 ->
+      Error (`Msg "couldn't parse priority: expected '>' earlier")
     | Some pri_end ->
       match String.with_range ~first:1 ~len:(pri_end - 1) s |> String.to_int with
-      | None -> None
+      | None -> Error (`Msg "couldn't parse priority: conversion to int failed")
       | Some priority_value ->
         let facility = facility_of_int @@ priority_value / 8
         and severity = severity_of_int @@ priority_value mod 8
         in
         match facility, severity with
-        | Invalid_Facility, _ -> None
-        | _, Invalid_Severity -> None
-        | facility, severity ->
+        | None, _ -> Error (`Msg "invalid facility")
+        | _, None -> Error (`Msg "invalid severity")
+        | Some facility, Some severity ->
           let first = succ pri_end in
           let len = l - first in
           let data = String.with_range ~first ~len s in
-          Some (facility, severity, data)
+          Ok (facility, severity, data)
 
-let parse_hostname s (ctx : ctx) =
+let parse_hostname s (ctx : ctx) : (string * string, [> Rresult.R.msg ]) result =
   if ctx.set_hostname then
-    Some (ctx.hostname, s)
+    Ok (ctx.hostname, s)
   else
-    match String.length s with
-    | l when l > 1 ->
-      (match String.find (fun x -> x = ' ') s with
-       | Some i when i > 0 ->
-         let hostname = String.with_range ~first:0 ~len:i s in
-         let hostnamelen = String.length hostname in
-         let data = String.with_range ~first:(i + 1) ~len:(l - i - 1) s in
-         let len = pred hostnamelen in
-         if String.get hostname len = ':' then
-           Some (String.with_range ~first:0 ~len hostname, data)
-         else
-           Some (hostname, data)
-       | _ -> None)
-    | _ -> None
+    match String.cut ~sep:" " s with
+    | None | Some ("", _) -> Error (`Msg "invalid or empty hostname")
+    | Some (host, data) ->
+      (match String.cut ~sep:":" ~rev:true host with
+       | None -> Ok host
+       | Some (host', "") -> Ok host'
+       | Some _ -> Error (`Msg "invalid empty hostname")) >>| fun hostname ->
+      (hostname, data)
 
 let parse_timestamp s (ctx : ctx) =
   let ((year, _, _), _) = Ptime.to_date_time ctx.timestamp in
   match Rfc3164_Timestamp.decode s year with
-  | Some (timestamp, data) -> Some (timestamp, data, ctx)
-  | None ->
+  | Ok (timestamp, data) -> Ok (timestamp, data, ctx)
+  | Error _ ->
     let ctx = { ctx with set_hostname = true } in
-    Some (ctx.timestamp, s, ctx)
+    Ok (ctx.timestamp, s, ctx)
 
-let bind o f =
-  match o with
-  | None -> None
-  | Some x -> f x
-
-let (>>=) o f = bind o f
+let parse_tag s : (string * string, [> Rresult.R.msg ]) result =
+  let tag, msg = String.span ~sat:Char.Ascii.is_alphanum s in
+  if String.length tag > 32 then
+    Error (`Msg "tag exceeds 32 characters")
+  else
+    Ok (tag, msg)
 
 (* FIXME Provide default Ptime.t? Version bellow doesn't work. Option type
 let parse ?(ctx={timestamp=(Ptime.of_date_time ((1970, 1, 1), ((0, 0,0), 0))); hostname="-"; set_hostname=false}) data =
 *)
-let decode ~ctx data =
-  match String.length data with
-  | l when l > 0 && l < 1025 ->
+let decode ~ctx data : (t, [> Rresult.R.msg ]) result =
+  let l = String.length data in
+  if l > 0 && l < 1025 then
     parse_priority_value data >>= fun (facility, severity, data) ->
     parse_timestamp data ctx >>= fun (timestamp, data, ctx) ->
     parse_hostname data ctx >>= fun (hostname, data) ->
-    Some {facility; severity; timestamp; hostname; message=data}
-  | _ -> None
+    parse_tag data >>= fun (tag, message) ->
+    Ok { facility; severity; timestamp; hostname; tag; message }
+  else
+    Error (`Msg "could not decode data")

--- a/src/syslog_message.ml
+++ b/src/syslog_message.ml
@@ -247,14 +247,22 @@ let encode_gen encode ?len msg =
     else
       msgstr
 
+let separator s =
+  match String.head s with
+  | Some c when not (Char.Ascii.is_alphanum c) -> ""
+  | Some _ | None -> " "
+
 let encode ?len msg =
-  let encode facse ts hostname tag msg =
-    Printf.sprintf "<%d>%s %s %s%s" facse ts hostname tag msg
+  let encode facse ts hostname tag content =
+    Printf.sprintf "<%d>%s %s %s%s%s" facse ts hostname tag
+      (separator content) content
   in
   encode_gen encode ?len msg
 
 let encode_local ?len msg =
-  let encode facse ts _ tag msg = Printf.sprintf "<%d>%s %s%s" facse ts tag msg in
+  let encode facse ts _ tag content =
+    Printf.sprintf "<%d>%s %s%s%s" facse ts tag (separator content) content
+  in
   encode_gen encode ?len msg
 
 let parse_priority_value s :

--- a/src/syslog_message.mli
+++ b/src/syslog_message.mli
@@ -35,7 +35,6 @@ type facility =
   | Local5
   | Local6
   | Local7
-  | Invalid_Facility
 
 (** [string_of_facility f] is [data], the string representation of [f]. *)
 val string_of_facility : facility -> string
@@ -50,7 +49,6 @@ type severity =
   | Notice
   | Informational
   | Debug
-  | Invalid_Severity
 
 (** [string_of_severity s] is [data], the string representation of [s]. *)
 val string_of_severity : severity -> string
@@ -76,6 +74,7 @@ type t = {
   severity : severity;
   timestamp : Ptime.t;
   hostname : string;
+  tag : string;
   message : string;
 }
 
@@ -85,9 +84,9 @@ val pp : Format.formatter -> t -> unit
 (** [to_string t] is [str], a pretty printed string of syslog message [t]. *)
 val to_string : t -> string
 
-(** [decode ~ctx data] is [t option], either [Some t], a successfully decoded
-    syslog message, or [None]. *)
-val decode : ctx:ctx -> string -> t option
+(** [decode ~ctx data] is [t], either [Ok t], a successfully decoded
+    syslog message, or [Error e]. *)
+val decode : ctx:ctx -> string -> (t, [> Rresult.R.msg ]) result
 
 (** [encode ~len t] is [data], the encoded syslog message [t], truncated to
     [len] bytes (defaults to 1024).  If [len] is 0 the output is not
@@ -104,7 +103,7 @@ module Rfc3164_Timestamp : sig
   (** [encode t] is [data], a timestamp in the presentation of RFC 3164.  *)
   val encode : Ptime.t -> string
 
-  (** [decode data year] is [timestamp, leftover], the decoded RFC 3164
-      timestamp and superfluous bytes, or None on parse failure.  *)
-  val decode : string -> int -> (Ptime.t * string) option
+  (** [decode data year] is [Ok (timestamp, leftover)], the decoded RFC 3164
+      timestamp and superfluous bytes, or [Error e] on parse failure.  *)
+  val decode : string -> int -> (Ptime.t * string, [> Rresult.R.msg ]) result
 end

--- a/src/syslog_message.mli
+++ b/src/syslog_message.mli
@@ -75,7 +75,7 @@ type t = {
   timestamp : Ptime.t;
   hostname : string;
   tag : string;
-  message : string;
+  content : string;
 }
 
 (** [pp ppf t] prints the syslog message [t] on [ppf]. *)

--- a/syslog-message.opam
+++ b/syslog-message.opam
@@ -19,6 +19,7 @@ depends: [
   "dune" {>= "1.1.0" & build}
   "astring"
   "ptime"
+  "rresult"
   "qcheck" {test}
 ]
 available: [ ocaml-version >= "4.02.3" ]

--- a/syslog-message.opam
+++ b/syslog-message.opam
@@ -8,6 +8,7 @@ bug-reports: "https://github.com/verbosemode/syslog-message/issues"
 doc: "https://verbosemode.github.io/syslog-message/doc"
 
 build: [
+  [ "dune" "subst" ] {pinned}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 

--- a/syslog-message.opam
+++ b/syslog-message.opam
@@ -22,4 +22,4 @@ depends: [
   "rresult"
   "qcheck" {test}
 ]
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.03.0" ]

--- a/test/test_syslog_message.ml
+++ b/test/test_syslog_message.ml
@@ -61,8 +61,8 @@ let valid_data_succeeds =
         Printf.sprintf "<%d>%s %s: Whatever" pri (Rfc3164_Timestamp.encode pt) host
       in
       match decode ~ctx msg with
-      | None -> false
-      | Some parsed ->
+      | Error _ -> false
+      | Ok parsed ->
         let ((_, m, d), ((hh, mm, ss), _)) = Ptime.to_date_time parsed.timestamp in
         let ((_, m', d'), ((hh', mm', ss'), _)) = Ptime.to_date_time pt in
         m = m' && d = d' && hh = hh' && mm = mm' && ss = ss' &&
@@ -85,8 +85,8 @@ let invalid_timestamp =
       in
       let ctx = { timestamp = valid; hostname = ""; set_hostname = false } in
       match decode ~ctx msg with
-      | None -> false
-      | Some parsed -> parsed.timestamp = valid
+      | Error _ -> false
+      | Ok parsed -> parsed.timestamp = valid
 
 let invalid_data_fails =
   QCheck.Test.make ~count:100
@@ -94,7 +94,9 @@ let invalid_data_fails =
   QCheck.string
   @@ fun msg ->
     let ctx = { timestamp = Ptime.epoch; hostname = ""; set_hostname = false } in
-    decode ~ctx msg = None
+    match decode ~ctx msg with
+    | Error _ -> true
+    | Ok _ -> false
 
 let () =
   let suite = [invalid_data_fails; valid_data_succeeds; invalid_timestamp] in


### PR DESCRIPTION
use rresult and result types (instead of option)

- this also removes two `failwith` (`Invalid_severity` / `Invalid_facility`) by adjusting `F|S_of_int` to return an `F|S option`.
- I'm curious about the `decode` function checking for `< 1025` -- is this a limit only for UDP or also for other transports?

There's a comment in the code:
```OCaml
(* FIXME Provide default Ptime.t? Version bellow doesn't work. Option type
let parse ?(ctx={timestamp=(Ptime.of_date_time ((1970, 1, 1), ((0, 0,0), 0))); hostname="-"; set_hostname=false}) data =
*)
```
You can use `Ptime.epoch` for this -- but I still wonder what `decode` should accept!? a syslog packet without timestamp?  without hostname? (I suspect the way forward is to move to 5424 ;)

in case this is accepted, I'm happy to adjust my logs-syslog with the revised types

EDIT: the type annotations in syslog_message.ml (`: ('a, [> Rresult.R.msg ]) result`) are necessary since otherwise the locally defined `Error` constructor (from `type severity`) is used.