### PR TITLE
Prepare 0.0.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+* Warning: encode function no longer truncates messages to 1024 bytes by default
 * split message part into tag and content (#20, by @hannesm)
 * use result types instead of option (#20, by @hannesm)
 * remove transport-dependent length check from encode (#20, by @hannesm)

--- a/src/syslog_message.mli
+++ b/src/syslog_message.mli
@@ -89,8 +89,10 @@ val to_string : t -> string
 val decode : ctx:ctx -> string -> (t, [> Rresult.R.msg ]) result
 
 (** [encode ~len t] is [data], the encoded syslog message [t], truncated to
-    [len] bytes (defaults to 1024).  If [len] is 0 the output is not
-    truncated. *)
+    [len] bytes. If [len] is 0 the output is not truncated.
+
+    {e Warning:} Since version 0.0.3, messages are no longer truncated to 1024
+    bytes by default. *)
 val encode : ?len:int -> t -> string
 
 (** [encode_local ~len t] behaves as {!encode} except that the message is


### PR DESCRIPTION
I've just added a few words to document the changes to the default behavior in encode. Should we make the 0.0.03 release now?