### PR TITLE
remove dependency on astring

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,4 @@
   (name        syslog_message)
   (public_name syslog-message)
   (synopsis    "Syslog Message Parser")
-  (libraries   astring ptime))
+  (libraries   ptime))

--- a/syslog-message.opam
+++ b/syslog-message.opam
@@ -10,7 +10,6 @@ license: "BSD-2-Clause"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "astring"
   "ptime"
   "qcheck" {with-test}
 ]


### PR DESCRIPTION
Since String.split_on_char is in the Stdlib, we can use that. This reduces the dependency cone of this library.

If accepted, I'd appreciate a release :)